### PR TITLE
Ensure install scripts use dependency-aware ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ end;
   ```
 - When every object in the capture is present in the uploaded JSON the procedure returns `NULL`, signalling that there is nothing left to install.
 
+### Installation order
+
+The generated script already follows the order expected by a clean installation. When iterating over captured metadata the package applies an explicit sort key so statements are emitted in dependency-friendly batches:
+
+1. Sequences
+2. Tables
+3. Indexes
+4. Triggers
+5. Views
+6. Package specifications
+7. Package bodies
+8. Procedures
+9. Functions
+
+Within each group objects are ordered by name. This means structures required by later objects—such as tables referenced by indexes, triggers, or PL/SQL—are always installed first. The package relies on `DBMS_METADATA.GET_DDL`, so each statement includes its dependent metadata (for example, table-level constraints), allowing the script to run from top to bottom on a brand-new database without additional orchestration.
+
+If you need a different ordering—for example to group related modules together—you can switch an object type to the `CUSTOM` strategy in `OEI_INSTALL_SCRIPT_STRATEGY` and point it to a hand-crafted script.
+
 ## Database objects
 
 The project now includes a configuration table responsible for defining how installation scripts are produced:

--- a/sql/modules/env_sync_capture/env_sync_capture_pkg.pkb
+++ b/sql/modules/env_sync_capture/env_sync_capture_pkg.pkb
@@ -330,7 +330,19 @@ create or replace package body env_sync_capture_pkg as
                    'PACKAGE BODY',
                    'TRIGGER',
                    'INDEX')
-             order by object_type, object_name)
+             order by case object_type
+                         when 'SEQUENCE' then 1
+                         when 'TABLE' then 2
+                         when 'INDEX' then 3
+                         when 'TRIGGER' then 4
+                         when 'VIEW' then 5
+                         when 'PACKAGE' then 6
+                         when 'PACKAGE BODY' then 7
+                         when 'PROCEDURE' then 8
+                         when 'FUNCTION' then 9
+                         else 100
+                      end,
+                      object_name)
         loop
             capture_object(in_schema_name => in_schema_name,
                            in_object_type => obj.object_type,
@@ -379,7 +391,19 @@ create or replace package body env_sync_capture_pkg as
                             where so.schema_name = upper(nvl(cmp.schema_name, in_schema_name))
                               and so.object_type = upper(cmp.object_type)
                               and so.object_name = upper(cmp.object_name))
-                 order by so.object_type, so.object_name)
+                 order by case so.object_type
+                             when 'SEQUENCE' then 1
+                             when 'TABLE' then 2
+                             when 'INDEX' then 3
+                             when 'TRIGGER' then 4
+                             when 'VIEW' then 5
+                             when 'PACKAGE' then 6
+                             when 'PACKAGE BODY' then 7
+                             when 'PROCEDURE' then 8
+                             when 'FUNCTION' then 9
+                             else 100
+                          end,
+                          so.object_name)
             loop
                 append_ddl(get_object_ddl(in_schema_name => in_schema_name,
                                           in_object_type => obj.object_type,
@@ -398,7 +422,19 @@ create or replace package body env_sync_capture_pkg as
                 select so.object_type, so.object_name
                   from oei_env_sync_schema_objects so
                  where so.schema_name = upper(in_schema_name)
-                 order by so.object_type, so.object_name)
+                 order by case so.object_type
+                             when 'SEQUENCE' then 1
+                             when 'TABLE' then 2
+                             when 'INDEX' then 3
+                             when 'TRIGGER' then 4
+                             when 'VIEW' then 5
+                             when 'PACKAGE' then 6
+                             when 'PACKAGE BODY' then 7
+                             when 'PROCEDURE' then 8
+                             when 'FUNCTION' then 9
+                             else 100
+                          end,
+                          so.object_name)
             loop
                 append_ddl(get_object_ddl(in_schema_name => in_schema_name,
                                           in_object_type => obj.object_type,


### PR DESCRIPTION
## Summary
- enforce a dependency-aware sort order when capturing objects and generating install scripts
- document the exact sequence used so new installations run without manual reordering

## Testing
- not run (logic change relies on existing package)

------
https://chatgpt.com/codex/tasks/task_e_68de7e986be4833284d00c324fc114ed